### PR TITLE
Support multiple values files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
           - "*"
 
   - package-ecosystem: gomod
+    directory: /
     commit-message:
       prefix: ":arrow_up:"
     schedule:

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"os"
 	"testing"
+
+	"helm.sh/helm/v3/pkg/cli/values"
 )
 
 func TestValidateChartValues(t *testing.T) {
@@ -74,5 +77,73 @@ func TestValidateChartValues(t *testing.T) {
 				t.Errorf("validateChartValues() issuesFound = %v, want %v", issuesFound, tt.wantIssues)
 			}
 		})
+	}
+}
+
+// TestMergeValues verifies that merging multiple values files produces the expected result.
+// In this test, we create two temporary YAML files. Values from the second file should override
+// those from the first.
+func TestMergeValues(t *testing.T) {
+	// Create the first temporary values file.
+	file1, err := os.CreateTemp("", "values1-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file1.Name())
+
+	// Create the second temporary values file.
+	file2, err := os.CreateTemp("", "values2-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file2.Name())
+
+	// Write YAML content into the first file.
+	content1 := `
+key1: value1
+nested:
+  key2: value2
+`
+	if _, err := file1.WriteString(content1); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	file1.Close()
+
+	// Write YAML content into the second file.
+	content2 := `
+key1: override
+nested:
+  key2: override2
+  key3: value3
+`
+	if _, err := file2.WriteString(content2); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	file2.Close()
+
+	// Use Helm's values.Options to merge the two files.
+	valueOpts := &values.Options{
+		ValueFiles: []string{file1.Name(), file2.Name()},
+	}
+	merged, err := valueOpts.MergeValues(nil)
+	if err != nil {
+		t.Fatalf("MergeValues() returned error: %v", err)
+	}
+
+	// Check that the key from the second file overrides the first.
+	if merged["key1"] != "override" {
+		t.Errorf("expected key1 to be 'override', got %v", merged["key1"])
+	}
+
+	// Verify nested keys.
+	nested, ok := merged["nested"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nested to be map[string]interface{}")
+	}
+	if nested["key2"] != "override2" {
+		t.Errorf("expected nested.key2 to be 'override2', got %v", nested["key2"])
+	}
+	if nested["key3"] != "value3" {
+		t.Errorf("expected nested.key3 to be 'value3', got %v", nested["key3"])
 	}
 }


### PR DESCRIPTION
This pull request introduces support for handling multiple values files in the Helm chart validation tool. The main changes include the addition of a new `ValueFiles` type to manage multiple values files, updates to the command-line interface to accept multiple values files, and new tests to verify the merging of these files.

Changes to support multiple values files:

* Added `ValueFiles` type to manage multiple values files, including methods `String` and `Set` to handle command-line input (`cmd/main.go`).
* Updated the command-line interface to accept multiple values files using the `-f` flag and modified the usage message accordingly (`cmd/main.go`).
* Replaced single values file handling with the new `ValueFiles` type in the main function (`cmd/main.go`) [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L154-R165) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L166-R177).

Testing enhancements:

* Added a new test `TestMergeValues` to verify that merging multiple values files produces the expected result, ensuring that values from subsequent files override those from earlier ones (`cmd/main_test.go`).