### PR TITLE
fix: validate dictEnv secretKeyRef / configMapKeyRef YAML shape

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,44 @@ func shouldIgnore(path string, ignoreList IgnoreList) bool {
 	return false
 }
 
+// validateDictEnvMapValue catches a common YAML mistake: name/key indented at the same
+// level as secretKeyRef (or configMapKeyRef), so they become siblings of the ref instead
+// of nested inside it — secretKeyRef ends up null while name/key sit at the top level.
+func validateDictEnvMapValue(fullKey string, m map[string]interface{}, issuesFound *bool) {
+	validateRefIndent(fullKey, m, "secretKeyRef", issuesFound)
+	validateRefIndent(fullKey, m, "configMapKeyRef", issuesFound)
+}
+
+func validateRefIndent(fullKey string, m map[string]interface{}, ref string, issuesFound *bool) {
+	v, has := m[ref]
+	if !has {
+		return
+	}
+	empty := v == nil
+	if !empty {
+		inner, ok := v.(map[string]interface{})
+		if !ok {
+			return
+		}
+		empty = len(inner) == 0
+	}
+	if !empty {
+		return
+	}
+	for _, sib := range []string{"name", "key"} {
+		val, ok := m[sib]
+		if !ok || val == nil {
+			continue
+		}
+		if s, isStr := val.(string); isStr && s == "" {
+			continue
+		}
+		fmt.Printf("❌ Invalid '%s': %q must be nested under %s (check YAML indentation)\n", fullKey, sib, ref)
+		*issuesFound = true
+		return
+	}
+}
+
 func validateChartValues(defaultValues, providedValues map[string]interface{}, prefix string, issuesFound *bool, ignoreList IgnoreList) {
 	for key, providedValue := range providedValues {
 		fullKey := key
@@ -61,6 +99,11 @@ func validateChartValues(defaultValues, providedValues map[string]interface{}, p
 
 		defaultValue, exists := defaultValues[key]
 		if !exists {
+			if prefix == "dictEnv" {
+				if em, ok := providedValue.(map[string]interface{}); ok {
+					validateDictEnvMapValue(fullKey, em, issuesFound)
+				}
+			}
 			//fmt.Printf("❌ Unexpected key: '%s' is not defined in chart defaults\n", fullKey)
 			//*issuesFound = true
 			continue

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -68,6 +68,54 @@ func TestValidateChartValues(t *testing.T) {
 			ignoreList: IgnoreList{"resources"},
 			wantIssues: false,
 		},
+		{
+			name: "dictEnv secretKeyRef indent mistake",
+			defaultValues: map[string]interface{}{
+				"dictEnv": map[string]interface{}{},
+			},
+			providedValues: map[string]interface{}{
+				"dictEnv": map[string]interface{}{
+					"AUTHN_PUBLIC_SECRET": map[string]interface{}{
+						"secretKeyRef": nil,
+						"name":         "sid-embark",
+						"key":          "secret",
+					},
+				},
+			},
+			ignoreList: IgnoreList{},
+			wantIssues: true,
+		},
+		{
+			name: "dictEnv secretKeyRef ok",
+			defaultValues: map[string]interface{}{
+				"dictEnv": map[string]interface{}{},
+			},
+			providedValues: map[string]interface{}{
+				"dictEnv": map[string]interface{}{
+					"AUTHN_PUBLIC_SECRET": map[string]interface{}{
+						"secretKeyRef": map[string]interface{}{
+							"name": "sid-embark",
+							"key":  "secret",
+						},
+					},
+				},
+			},
+			ignoreList: IgnoreList{},
+			wantIssues: false,
+		},
+		{
+			name: "dictEnv scalar ok",
+			defaultValues: map[string]interface{}{
+				"dictEnv": map[string]interface{}{},
+			},
+			providedValues: map[string]interface{}{
+				"dictEnv": map[string]interface{}{
+					"FOO": "bar",
+				},
+			},
+			ignoreList: IgnoreList{},
+			wantIssues: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "kc"
-version: "0.2.0"
+version: "0.3.1"
 usage: "KaartControle: validate Helm chart values against defaults"
 description: "A Helm plugin to detect redundant and mismatched values in your value files"
 command: "$HELM_PLUGIN_DIR/bin/kc"


### PR DESCRIPTION
To detect stuff like this (missing indent): 
```
    secretKeyRef:
    name: sid-embark-indexing
    key: secret
```

When chart defaults use an empty `dictEnv: {}`, merged keys were skipped entirely. Validate map-valued `dictEnv.*` entries: if `secretKeyRef` or `configMapKeyRef` is empty/null but `name`/`key` appear as siblings (common YAML indent mistake), fail with a clear message.

Includes unit tests. Plugin version bumped to 0.3.1 for release.